### PR TITLE
쿠폰 발급 및 검색 기능 개발

### DIFF
--- a/src/main/java/com/qring/coupon/application/v1/res/CouponGetByIdResDTOV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/res/CouponGetByIdResDTOV1.java
@@ -1,7 +1,6 @@
 package com.qring.coupon.application.v1.res;
 
 import com.qring.coupon.domain.model.CouponEntity;
-import com.qring.coupon.domain.model.constraint.CouponStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,7 +32,7 @@ public class CouponGetByIdResDTOV1 {
         private String name;
         private int discount;
         private int totalQuantity;
-        private int remainQuantity;
+        private int remainingQuantity;
         private LocalDateTime openAt;
         private LocalDateTime expiredAt;
         private String couponStatus;
@@ -44,7 +43,7 @@ public class CouponGetByIdResDTOV1 {
                     .name(couponEntity.getName())
                     .discount(couponEntity.getDiscount())
                     .totalQuantity(couponEntity.getTotalQuantity())
-                    .remainQuantity(couponEntity.getRemainQuantity())
+                    .remainingQuantity(couponEntity.getRemainingQuantity())
                     .openAt(couponEntity.getOpenAt())
                     .expiredAt(couponEntity.getExpiredAt())
                     .couponStatus(couponEntity.getCouponStatus().getStatus())

--- a/src/main/java/com/qring/coupon/application/v1/res/CouponPostByIdResDTOV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/res/CouponPostByIdResDTOV1.java
@@ -1,8 +1,6 @@
 package com.qring.coupon.application.v1.res;
 
 import com.qring.coupon.domain.model.CouponEntity;
-import com.qring.coupon.domain.model.UserCouponEntity;
-import com.qring.coupon.domain.model.constraint.CouponStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +33,8 @@ public class CouponPostByIdResDTOV1 {
         private int discount;
         private LocalDateTime openAt;
         private LocalDateTime expiredAt;
-        private CouponStatus couponStatus;
+        private String couponStatus;
+        private String issuanceStatus;
 
         public static Coupon from(CouponEntity couponEntity) {
             return Coupon.builder()
@@ -44,7 +43,8 @@ public class CouponPostByIdResDTOV1 {
                     .discount(couponEntity.getDiscount())
                     .openAt(couponEntity.getOpenAt())
                     .expiredAt(couponEntity.getExpiredAt())
-                    .couponStatus(couponEntity.getCouponStatus())
+                    .couponStatus(couponEntity.getCouponStatus().getStatus())
+                    .issuanceStatus(couponEntity.getIssuanceStatus().getStatus())
                     .build();
         }
     }

--- a/src/main/java/com/qring/coupon/application/v1/res/CouponPostResDTOV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/res/CouponPostResDTOV1.java
@@ -32,7 +32,7 @@ public class CouponPostResDTOV1 {
         private String name;
         private int discount;
         private int totalQuantity;
-        private int remainQuantity;
+        private int remainingQuantity;
         private LocalDateTime openAt;
         private LocalDateTime expiredAt;
         private String couponStatus;
@@ -43,7 +43,7 @@ public class CouponPostResDTOV1 {
                     .name(couponEntity.getName())
                     .discount(couponEntity.getDiscount())
                     .totalQuantity(couponEntity.getTotalQuantity())
-                    .remainQuantity(couponEntity.getRemainQuantity())
+                    .remainingQuantity(couponEntity.getRemainingQuantity())
                     .openAt(couponEntity.getOpenAt())
                     .expiredAt(couponEntity.getExpiredAt())
                     .couponStatus(couponEntity.getCouponStatus().getStatus())

--- a/src/main/java/com/qring/coupon/application/v1/res/CouponSearchResDTOV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/res/CouponSearchResDTOV1.java
@@ -50,7 +50,7 @@ public class CouponSearchResDTOV1 {
             private String name;
             private int discount;
             private int totalQuantity;
-            private int remainQuantity;
+            private int remainingQuantity;
             private LocalDateTime openAt;
             private LocalDateTime expiredAt;
             private String couponStatus;
@@ -68,7 +68,7 @@ public class CouponSearchResDTOV1 {
                         .name(couponEntity.getName())
                         .discount(couponEntity.getDiscount())
                         .totalQuantity(couponEntity.getTotalQuantity())
-                        .remainQuantity(couponEntity.getRemainQuantity())
+                        .remainingQuantity(couponEntity.getRemainingQuantity())
                         .openAt(couponEntity.getOpenAt())
                         .expiredAt(couponEntity.getExpiredAt())
                         .couponStatus(couponEntity.getCouponStatus().getStatus())

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -5,16 +5,18 @@ import com.qring.coupon.application.global.exception.DuplicateResourceException;
 import com.qring.coupon.application.global.exception.EntityNotFoundException;
 import com.qring.coupon.application.global.exception.UnauthorizedAccessException;
 import com.qring.coupon.application.v1.res.CouponGetByIdResDTOV1;
+import com.qring.coupon.application.v1.res.CouponPostByIdResDTOV1;
 import com.qring.coupon.application.v1.res.CouponPostResDTOV1;
 import com.qring.coupon.application.v1.res.CouponSearchResDTOV1;
 import com.qring.coupon.domain.model.CouponEntity;
+import com.qring.coupon.domain.model.UserCouponEntity;
 import com.qring.coupon.domain.model.constraint.IssuanceStatus;
 import com.qring.coupon.domain.repository.CouponRepository;
+import com.qring.coupon.domain.repository.UserCouponRepository;
 import com.qring.coupon.infrastructure.util.PassportUtil;
 import com.qring.coupon.presentation.v1.req.PostCouponReqDTOV1;
 import com.qring.coupon.presentation.v1.req.PutCouponReqDTOV1;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.builder.Builder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
 public class CouponServiceV1 {
 
     private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
 
     @Transactional
     public CouponPostResDTOV1 postBy(String passport, PostCouponReqDTOV1 dto) {
@@ -42,6 +45,32 @@ public class CouponServiceV1 {
         );
 
         return CouponPostResDTOV1.of(couponRepository.save(couponEntityForSave));
+    }
+
+    @Transactional
+    public CouponPostByIdResDTOV1 issueBy(String passport, Long id) {
+
+        CouponEntity couponEntityForCheck = getCouponEntityById(id);
+
+        if (!couponEntityForCheck.getIssuanceStatus().getStatus().equals("개시")) {
+            throw new BadRequestException("해당 쿠폰은 발급이 불가능합니다.");
+        }
+
+        if (couponEntityForCheck.getRemainQuantity() <= 0) {
+            throw new BadRequestException("쿠폰이 매진되었습니다.");
+        }
+
+        if (userCouponRepository.existsByUserIdAndCouponEntity(PassportUtil.getUserId(passport), couponEntityForCheck)) {
+            throw new DuplicateResourceException("이미 보유하고 있는 쿠폰입니다.");
+        }
+
+        UserCouponEntity userCouponEntityForSave = UserCouponEntity.createUserCouponEntity(couponEntityForCheck, PassportUtil.getUserId(passport));
+        userCouponRepository.save(userCouponEntityForSave);
+
+        couponEntityForCheck.remainQuantityForDecrease();
+        couponRepository.save(couponEntityForCheck);
+
+        return CouponPostByIdResDTOV1.of(couponEntityForCheck);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -67,9 +67,6 @@ public class CouponServiceV1 {
         UserCouponEntity userCouponEntityForSave = UserCouponEntity.createUserCouponEntity(couponEntityForCheck, PassportUtil.getUserId(passport));
         userCouponRepository.save(userCouponEntityForSave);
 
-        couponEntityForCheck.remainQuantityForDecrease();
-        couponRepository.save(couponEntityForCheck);
-
         return CouponPostByIdResDTOV1.of(couponEntityForCheck);
     }
 

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -88,7 +88,7 @@ public class CouponServiceV1 {
 
         CouponEntity couponEntityForModification = getCouponEntityById(id);
 
-        validateMasterRole(passport);
+        validateUserRole(passport);
 
         validateCouponNameDuplicate(id, dto.getCoupon().getName());
 
@@ -123,7 +123,7 @@ public class CouponServiceV1 {
     // -----
     // NOTE : 쿠폰 생성 검증 프로세스
     private void validateCouponCreationProcess(String passport, PostCouponReqDTOV1 dto) {
-        validateMasterRole(passport);
+        validateUserRole(passport);
 
         validateCouponNameDuplicate(dto.getCoupon().getName());
 
@@ -140,7 +140,7 @@ public class CouponServiceV1 {
 
     // -----
     // NOTE : 관리자 권한 검증
-    private void validateMasterRole(String passport) {
+    private void validateUserRole(String passport) {
         if (!PassportUtil.getRole(passport).equals("관리자")) {
             throw new UnauthorizedAccessException("쿠폰 생성 권한이 없습니다.");
         }

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -142,7 +142,7 @@ public class CouponServiceV1 {
     // -----
     // NOTE : 관리자 권한 검증
     private void validateUserRole(String passport) {
-        if (!PassportUtil.getRole(passport).equals("관리자")) {
+        if (!Objects.equals(PassportUtil.getRole(passport), "관리자")) {
             throw new UnauthorizedAccessException("쿠폰 생성 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -53,7 +53,7 @@ public class CouponServiceV1 {
 
         CouponEntity couponEntityForCheck = getCouponEntityById(id);
 
-        if (couponEntityForCheck.getRemainQuantity() <= 0) {
+        if (couponEntityForCheck.getRemainingQuantity() <= 0) {
             throw new BadRequestException("쿠폰이 매진되었습니다.");
         }
 
@@ -93,9 +93,9 @@ public class CouponServiceV1 {
 
         validateCouponNameDuplicate(id, dto.getCoupon().getName());
 
-        int remainQuantity = getRemainQuantity(dto.getCoupon().getTotalQuantity(), couponEntityForModification);
+        int remainingQuantity = getRemainingQuantity(dto.getCoupon().getTotalQuantity(), couponEntityForModification);
 
-        String issuanceStatus = getIssuanceStatus(dto.getCoupon().getIssuanceStatus(), remainQuantity);
+        String issuanceStatus = getIssuanceStatus(dto.getCoupon().getIssuanceStatus(), remainingQuantity);
 
         validateCouponDateRange(dto.getCoupon().getOpenAt(), dto.getCoupon().getExpiredAt());
 
@@ -103,7 +103,7 @@ public class CouponServiceV1 {
                 dto.getCoupon().getName(),
                 dto.getCoupon().getDiscount(),
                 dto.getCoupon().getTotalQuantity(),
-                remainQuantity,
+                remainingQuantity,
                 dto.getCoupon().getOpenAt(),
                 dto.getCoupon().getExpiredAt(),
                 dto.getCoupon().getCouponStatus(),
@@ -165,24 +165,24 @@ public class CouponServiceV1 {
 
     // -----
     // NOTE : 쿠폰 잔여 개수 반환
-    private int getRemainQuantity(int reqTotalQuantity, CouponEntity couponEntityForModification) {
+    private int getRemainingQuantity(int reqTotalQuantity, CouponEntity couponEntityForModification) {
         int totalQuantity = couponEntityForModification.getTotalQuantity();
-        int remainQuantity = couponEntityForModification.getRemainQuantity();
+        int remainingQuantity = couponEntityForModification.getRemainingQuantity();
 
         if (totalQuantity != reqTotalQuantity) {
             int count = reqTotalQuantity - totalQuantity;
-            remainQuantity += count;
-            if (remainQuantity < 0) {
+            remainingQuantity += count;
+            if (remainingQuantity < 0) {
                 throw new BadRequestException("쿠폰 잔여 개수가 부족합니다.");
             }
         }
-        return remainQuantity;
+        return remainingQuantity;
     }
 
     // -----
     // NOTE : 쿠폰 발행 가능 상태 반환
-    private String getIssuanceStatus(String issuanceStatus, int remainQuantity) {
-        return remainQuantity == 0 ? IssuanceStatus.Status.CLOSED : issuanceStatus;
+    private String getIssuanceStatus(String issuanceStatus, int remainingQuantity) {
+        return remainingQuantity == 0 ? IssuanceStatus.Status.CLOSED : issuanceStatus;
     }
 
     // -----

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -95,7 +95,7 @@ public class CouponServiceV1 {
 
         int remainingQuantity = getRemainingQuantity(dto.getCoupon().getTotalQuantity(), couponEntityForModification);
 
-        String issuanceStatus = getIssuanceStatus(dto.getCoupon().getIssuanceStatus(), remainingQuantity);
+        String issuanceStatus = getIssuanceStatusByRemainingQuantity(dto.getCoupon().getIssuanceStatus(), remainingQuantity);
 
         validateCouponDateRange(dto.getCoupon().getOpenAt(), dto.getCoupon().getExpiredAt());
 
@@ -181,7 +181,7 @@ public class CouponServiceV1 {
 
     // -----
     // NOTE : 쿠폰 발행 가능 상태 반환
-    private String getIssuanceStatus(String issuanceStatus, int remainingQuantity) {
+    private String getIssuanceStatusByRemainingQuantity(String issuanceStatus, int remainingQuantity) {
         return remainingQuantity == 0 ? IssuanceStatus.Status.CLOSED : issuanceStatus;
     }
 

--- a/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
+++ b/src/main/java/com/qring/coupon/application/v1/service/CouponServiceV1.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -52,16 +53,16 @@ public class CouponServiceV1 {
 
         CouponEntity couponEntityForCheck = getCouponEntityById(id);
 
-        if (!couponEntityForCheck.getIssuanceStatus().getStatus().equals("개시")) {
-            throw new BadRequestException("해당 쿠폰은 발급이 불가능합니다.");
-        }
-
         if (couponEntityForCheck.getRemainQuantity() <= 0) {
             throw new BadRequestException("쿠폰이 매진되었습니다.");
         }
 
         if (userCouponRepository.existsByUserIdAndCouponEntity(PassportUtil.getUserId(passport), couponEntityForCheck)) {
             throw new DuplicateResourceException("이미 보유하고 있는 쿠폰입니다.");
+        }
+
+        if (Objects.equals(couponEntityForCheck.getIssuanceStatus().getStatus(), "개시")) {
+            throw new BadRequestException("해당 쿠폰은 발급이 불가능합니다.");
         }
 
         UserCouponEntity userCouponEntityForSave = UserCouponEntity.createUserCouponEntity(couponEntityForCheck, PassportUtil.getUserId(passport));

--- a/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
@@ -103,7 +103,7 @@ public class CouponEntity {
                 .build();
     }
 
-    public void remainQuantityForDecrease() {
+    public void decreaseRemainingQuantity() {
         if(this.remainQuantity <= 0){
             throw new BadRequestException("재고 수량이 부족합니다.");
         }

--- a/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
@@ -1,5 +1,6 @@
 package com.qring.coupon.domain.model;
 
+import com.qring.coupon.application.global.exception.BadRequestException;
 import com.qring.coupon.domain.model.constraint.CouponStatus;
 import com.qring.coupon.domain.model.constraint.IssuanceStatus;
 import io.hypersistence.utils.hibernate.id.Tsid;
@@ -100,6 +101,14 @@ public class CouponEntity {
                 .issuanceStatus(IssuanceStatus.CLOSED)
                 .username(username)
                 .build();
+    }
+
+    public void remainQuantityForDecrease() {
+        if(this.remainQuantity <= 0){
+            throw new BadRequestException("재고 수량이 부족합니다.");
+        }
+
+        this.remainQuantity -= 1;
     }
 
     public void modifyCouponEntity(String name, int discount, int totalQuantity, int remainQuantity, LocalDateTime openAt, LocalDateTime expiredAt, String couponStatus, String issuanceStatus, String username) {

--- a/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/CouponEntity.java
@@ -36,7 +36,7 @@ public class CouponEntity {
     private int totalQuantity;
 
     @Column(name = "remain_quantity", nullable = false)
-    private int remainQuantity;
+    private int remainingQuantity;
 
     @Column(name = "open_at", nullable = false)
     private LocalDateTime openAt;
@@ -76,11 +76,11 @@ public class CouponEntity {
     private String deletedBy;
 
     @Builder
-    public CouponEntity(String name, int discount, int totalQuantity, int remainQuantity, LocalDateTime openAt, LocalDateTime expiredAt, CouponStatus couponStatus, IssuanceStatus issuanceStatus, String username) {
+    public CouponEntity(String name, int discount, int totalQuantity, int remainingQuantity, LocalDateTime openAt, LocalDateTime expiredAt, CouponStatus couponStatus, IssuanceStatus issuanceStatus, String username) {
         this.name = name;
         this.discount = discount;
         this.totalQuantity = totalQuantity;
-        this.remainQuantity = totalQuantity;
+        this.remainingQuantity = totalQuantity;
         this.openAt = openAt;
         this.expiredAt = expiredAt;
         this.couponStatus = couponStatus;
@@ -94,7 +94,7 @@ public class CouponEntity {
                 .name(name)
                 .discount(discount)
                 .totalQuantity(totalQuantity)
-                .remainQuantity(totalQuantity)
+                .remainingQuantity(totalQuantity)
                 .openAt(openAt)
                 .expiredAt(expiredAt)
                 .couponStatus(CouponStatus.INACTIVE)
@@ -104,18 +104,18 @@ public class CouponEntity {
     }
 
     public void decreaseRemainingQuantity() {
-        if(this.remainQuantity <= 0){
+        if(this.remainingQuantity <= 0){
             throw new BadRequestException("재고 수량이 부족합니다.");
         }
 
-        this.remainQuantity -= 1;
+        this.remainingQuantity -= 1;
     }
 
-    public void modifyCouponEntity(String name, int discount, int totalQuantity, int remainQuantity, LocalDateTime openAt, LocalDateTime expiredAt, String couponStatus, String issuanceStatus, String username) {
+    public void modifyCouponEntity(String name, int discount, int totalQuantity, int remainingQuantity, LocalDateTime openAt, LocalDateTime expiredAt, String couponStatus, String issuanceStatus, String username) {
         this.name = name;
         this.discount = discount;
         this.totalQuantity = totalQuantity;
-        this.remainQuantity = remainQuantity;
+        this.remainingQuantity = remainingQuantity;
         this.openAt = openAt;
         this.expiredAt = expiredAt;
         this.couponStatus = CouponStatus.fromString(couponStatus);

--- a/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
@@ -31,6 +31,7 @@ public class UserCouponEntity {
     }
 
     public static UserCouponEntity createUserCouponEntity(CouponEntity couponEntity, Long userId) {
+        couponEntity.remainQuantityForDecrease();
         return UserCouponEntity.builder()
                 .couponEntity(couponEntity)
                 .userId(userId)

--- a/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
@@ -31,7 +31,7 @@ public class UserCouponEntity {
     }
 
     public static UserCouponEntity createUserCouponEntity(CouponEntity couponEntity, Long userId) {
-        couponEntity.remainQuantityForDecrease();
+        couponEntity.decreaseRemainingQuantity();
         return UserCouponEntity.builder()
                 .couponEntity(couponEntity)
                 .userId(userId)

--- a/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
+++ b/src/main/java/com/qring/coupon/domain/model/UserCouponEntity.java
@@ -30,4 +30,10 @@ public class UserCouponEntity {
         this.couponEntity = couponEntity;
     }
 
+    public static UserCouponEntity createUserCouponEntity(CouponEntity couponEntity, Long userId) {
+        return UserCouponEntity.builder()
+                .couponEntity(couponEntity)
+                .userId(userId)
+                .build();
+    }
 }

--- a/src/main/java/com/qring/coupon/domain/repository/UserCouponRepository.java
+++ b/src/main/java/com/qring/coupon/domain/repository/UserCouponRepository.java
@@ -1,0 +1,12 @@
+package com.qring.coupon.domain.repository;
+
+import com.qring.coupon.domain.model.CouponEntity;
+import com.qring.coupon.domain.model.UserCouponEntity;
+
+public interface UserCouponRepository {
+
+    boolean existsByUserIdAndCouponEntity(Long userId, CouponEntity couponEntity);
+
+    UserCouponEntity save(UserCouponEntity userCouponEntity);
+
+}

--- a/src/main/java/com/qring/coupon/infrastructure/docs/CouponControllerSwagger.java
+++ b/src/main/java/com/qring/coupon/infrastructure/docs/CouponControllerSwagger.java
@@ -39,8 +39,8 @@ public interface CouponControllerSwagger {
             @ApiResponse(responseCode = "400", description = "쿠폰 발급 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
     })
     @PostMapping("/{id}/issue")
-    ResponseEntity<ResDTO<CouponPostByIdResDTOV1>> postBy(@RequestHeader("X-User-Id") Long userId,
-                                                          @Valid @PathVariable Long id);
+    ResponseEntity<ResDTO<CouponPostByIdResDTOV1>> issueBy(@RequestHeader("X-Passport-Token") String passport,
+                                                           @PathVariable Long id);
 
     @Operation(summary = "쿠폰 검색", description = "쿠폰을 검색하는 API 입니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/qring/coupon/infrastructure/repository/CouponQueryRepository.java
+++ b/src/main/java/com/qring/coupon/infrastructure/repository/CouponQueryRepository.java
@@ -25,7 +25,7 @@ public class CouponQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public Page<CouponEntity> couponEntityPageByDeletedAtIsNullWithConditions(Pageable pageable, Long userId, String name, String couponStatus, String issuanceStatus, String sort) {
-        List<CouponEntity> results = queryFactory
+        List<CouponEntity> resultList = queryFactory
                 .selectFrom(couponEntity)
                 .where(
                         couponEntity.deletedAt.isNull(),
@@ -52,7 +52,7 @@ public class CouponQueryRepository {
                         issuanceStatusEq(issuanceStatus)
                 );
 
-        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(resultList, pageable, countQuery::fetchOne);
     }
 
     private BooleanExpression userIdEq(Long userId) {

--- a/src/main/java/com/qring/coupon/infrastructure/repository/JpaUserCouponRepository.java
+++ b/src/main/java/com/qring/coupon/infrastructure/repository/JpaUserCouponRepository.java
@@ -1,0 +1,11 @@
+package com.qring.coupon.infrastructure.repository;
+
+import com.qring.coupon.domain.model.CouponEntity;
+import com.qring.coupon.domain.model.UserCouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserCouponRepository extends JpaRepository<UserCouponEntity, Long> {
+
+    boolean existsByUserIdAndCouponEntity(Long userId, CouponEntity couponEntity);
+
+}

--- a/src/main/java/com/qring/coupon/infrastructure/repository/UserCouponRepositoryImpl.java
+++ b/src/main/java/com/qring/coupon/infrastructure/repository/UserCouponRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.qring.coupon.infrastructure.repository;
+
+import com.qring.coupon.domain.model.CouponEntity;
+import com.qring.coupon.domain.model.UserCouponEntity;
+import com.qring.coupon.domain.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCouponRepositoryImpl implements UserCouponRepository {
+
+    private final JpaUserCouponRepository jpaUserCouponRepository;
+
+    @Override
+    public boolean existsByUserIdAndCouponEntity(Long userId, CouponEntity couponEntity) {
+        return jpaUserCouponRepository.existsByUserIdAndCouponEntity(userId, couponEntity);
+    }
+
+    @Override
+    public UserCouponEntity save(UserCouponEntity userCouponEntity) {
+        return jpaUserCouponRepository.save(userCouponEntity);
+    }
+
+}

--- a/src/main/java/com/qring/coupon/presentation/v1/controller/CouponControllerV1.java
+++ b/src/main/java/com/qring/coupon/presentation/v1/controller/CouponControllerV1.java
@@ -6,7 +6,6 @@ import com.qring.coupon.application.v1.res.CouponPostByIdResDTOV1;
 import com.qring.coupon.application.v1.res.CouponPostResDTOV1;
 import com.qring.coupon.application.v1.res.CouponSearchResDTOV1;
 import com.qring.coupon.application.v1.service.CouponServiceV1;
-import com.qring.coupon.domain.model.CouponEntity;
 import com.qring.coupon.infrastructure.docs.CouponControllerSwagger;
 import com.qring.coupon.presentation.v1.req.PostCouponReqDTOV1;
 import com.qring.coupon.presentation.v1.req.PutCouponReqDTOV1;
@@ -18,8 +17,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,23 +39,13 @@ public class CouponControllerV1 implements CouponControllerSwagger {
     }
 
     @PostMapping("/{id}/issue")
-    public ResponseEntity<ResDTO<CouponPostByIdResDTOV1>> postBy(@RequestHeader("X-User-Id") Long userId,
+    public ResponseEntity<ResDTO<CouponPostByIdResDTOV1>> issueBy(@RequestHeader("X-Passport-Token") String passport,
                                                                  @PathVariable Long id) {
-        /*
-         * TODO :  더미데이터입니다.
-         */
-        CouponEntity dummyCouponEntity = CouponEntity.builder()
-                .name("쿠폰1")
-                .discount(1000)
-                .openAt(LocalDateTime.of(2024, 12, 31, 12, 0))
-                .expiredAt(LocalDateTime.of(2025, 1, 15, 12, 0))
-                .build();
-
         return new ResponseEntity<>(
                 ResDTO.<CouponPostByIdResDTOV1>builder()
                         .code(HttpStatus.CREATED.value())
                         .message("쿠폰 발급에 성공하였습니다.")
-                        .data(CouponPostByIdResDTOV1.of(dummyCouponEntity))
+                        .data(couponServiceV1.issueBy(passport, id))
                         .build(),
                 HttpStatus.CREATED
         );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #10 

## 📝 Description

- 쿠폰 검색 기능 구현
  - Query DSL 을 사용하여 동적 쿼리 메서드를 구현하였습니다.
   
- 쿠폰 발급 기능 구현
  -  쿠폰 발급 상태가 "개시" 이어야만 발급가능합니다.
  -  쿠폰 남은 재고가 0 이하라면 발급이 불가능합니다.
  -  한 명의 사용자는 동일한 쿠폰 발급이 불가능합니다.
  -  쿠폰 발급 후 재고 감소
  
```java
if (!couponEntityForCheck.getIssuanceStatus().getStatus().equals("개시")) {
   throw new BadRequestException("해당 쿠폰은 발급이 불가능합니다.");
}

if (couponEntityForCheck.getRemainQuantity() <= 0) {
   throw new BadRequestException("쿠폰이 매진되었습니다.");
}

if (userCouponRepository.existsByUserIdAndCouponEntity(PassportUtil.getUserId(passport), couponEntityForCheck)) {
   throw new DuplicateResourceException("이미 보유하고 있는 쿠폰입니다.");
}

UserCouponEntity userCouponEntityForSave = UserCouponEntity.createUserCouponEntity(couponEntityForCheck, PassportUtil.getUserId(passport));

couponEntityForCheck.remainQuantityForDecrease();
```
`쿠폰 발급 실행 결과`
```
{
    "code": 201,
    "message": "쿠폰 발급에 성공하였습니다.",
    "data": {
        "coupon": {
            "id": 663027687465329520,
            "name": "쿠폰1",
            "discount": 1000,
            "openAt": "2025-01-12T15:30:00",
            "expiredAt": "2025-05-12T15:30:00",
            "couponStatus": "활성",
            "issuanceStatus": "개시"
        }
    }
}
```


## 💬 To Reivewers

먼저 사과드립니다. 검색 기능을 develop 브랜치에서 직접 구현하고 머지하여, 해당 코드 변경 내용을 develop 브랜치에서만 확인할 수 있습니다. 앞으로 작업 브랜치를 명확히 구분하여 진행하겠습니다.

- 쿠폰 발급 메서드 이름을 postBy에서 issueBy로 변경했는데, 이에 대한 팀원분들의 의견이 궁금합니다.
- 또한, 메서드 이름을 변경할 경우, 응답 DTO의 이름(CouponPostByIdResDTOV1)도 함께 변경하는 것이 좋을지 의견 부탁드립니다.
- 쿠폰 수정 시 재고 감소 부분 보완 예정입니다.
